### PR TITLE
update elan url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       - name: install elan
         run: |
           set -o pipefail
-          curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- --default-toolchain none -y
           ~/.elan/bin/lean --version
           echo "$HOME/.elan/bin" >> $GITHUB_PATH
 
@@ -179,7 +179,7 @@ jobs:
       - name: Install elan
         run: |
           set -o pipefail
-          curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- -v -y
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -v -y
           sudo ln -s $HOME/.elan/bin/* /usr/local/bin;
       - name: Install python Lean dependencies
         run: python -m pip install --upgrade pip requests markdown2 toml mathlibtools toposort invoke


### PR DESCRIPTION
The old URL was breaking builds in mathlib earlier today.